### PR TITLE
Fix missing tags property

### DIFF
--- a/semantics.json
+++ b/semantics.json
@@ -93,6 +93,7 @@
               "widget": "html",
               "label": "Scene description (for screen readers)",
               "description": "A text that can describe the scene for the end-user. It will not be visible but read by screen readers, so formatting will be ignored.",
+              "tags": [],
               "optional": true
             },
             {


### PR DESCRIPTION
When merged in, will add missing tags property in semantics.json that currently leads to a crash when opening the scene form in the editor.